### PR TITLE
Breaking: update rules for JSX closing bracket location

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -10,10 +10,7 @@ module.exports = {
     "react/jsx-boolean-value": [2, "never"],
     // Validate closing bracket location in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
-    "react/jsx-closing-bracket-location": [2, {
-      "nonEmpty": "after-props",
-      "selfClosing": "after-props",
-    }],
+    "react/jsx-closing-bracket-location": [2, "line-aligned"],
     // Disallow spaces inside of curly braces in JSX attributes
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
     "react/jsx-curly-spacing": [2, "never"],


### PR DESCRIPTION
This proposes an update to the rules regarding the location of the closing bracket for JSX tags.

For example, with this set of changes applied:

``` jsx
// bad
<Foo
  bar="bar"
  baz="baz" />

// good
<Foo
  bar="bar"
  baz="baz"
/>
```

There was some discussion in support of this recently and I also found myself wanting to use this style.

cc @Leland-Kwong @rygine @yanfali
