### PR TITLE
Update: add new rules, rename deprecated rules

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -89,9 +89,9 @@ module.exports = {
     // Disallow Multiline Strings
     // http://eslint.org/docs/rules/no-multi-str
     "no-multi-str": 2,
-    // Disallow Reassignment of Native Objects
-    // http://eslint.org/docs/rules/no-native-reassign
-    "no-native-reassign": 2,
+    // Disallow assignment to native objects or read-only global variables
+    // http://eslint.org/docs/rules/no-global-assign
+    "no-global-assign": 2,
     // Disallow Function Constructor
     // http://eslint.org/docs/rules/no-new-func
     "no-new-func": 2,

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -54,9 +54,6 @@ module.exports = {
     // Disallow irregular whitespace
     // http://eslint.org/docs/rules/no-irregular-whitespace
     "no-irregular-whitespace": 2,
-    // Disallow negated left operand of in operator
-    // http://eslint.org/docs/rules/no-negated-in-lhs
-    "no-negated-in-lhs": 2,
     // Disallow Global Object Function Calls
     // http://eslint.org/docs/rules/no-obj-calls
     "no-obj-calls": 2,
@@ -72,6 +69,9 @@ module.exports = {
     // Disallow control flow statements in finally blocks
     // http://eslint.org/docs/rules/no-unsafe-finally
     "no-unsafe-finally": 2,
+    // Disallow negating the left operand of relational operators
+    // http://eslint.org/docs/rules/no-unsafe-negation
+    "no-unsafe-negation": 2,
     // Require isNaN()
     // http://eslint.org/docs/rules/use-isnan
     "use-isnan": 2,

--- a/rules/es2015.js
+++ b/rules/es2015.js
@@ -60,6 +60,9 @@ module.exports = {
     // Suggest using template literals instead of string concatenation
     // http://eslint.org/docs/rules/prefer-template
     "prefer-template": 2,
+    // Require symbol description
+    // http://eslint.org/docs/rules/symbol-description
+    "symbol-description": 2,
     // Enforce spacing around the * in yield* expressions
     // http://eslint.org/docs/rules/yield-star-spacing
     "yield-star-spacing": [2, "before"],

--- a/rules/style.js
+++ b/rules/style.js
@@ -34,6 +34,9 @@ module.exports = {
     // Require files to end with single newline
     // http://eslint.org/docs/rules/eol-last
     "eol-last": 2,
+    // Disallow Spaces in Function Calls
+    // http://eslint.org/docs/rules/func-call-spacing
+    "func-call-spacing": [2, "never"],
     // Require Names for Function Expressions
     // http://eslint.org/docs/rules/func-names
     "func-names": 1,
@@ -98,15 +101,19 @@ module.exports = {
     // Disallow the use of the Object constructor
     // http://eslint.org/docs/rules/no-new-object
     "no-new-object": 2,
-    // Disallow Spaces in Function Calls
-    // http://eslint.org/docs/rules/no-spaced-func
-    "no-spaced-func": 2,
     // Disallow trailing spaces at the end of lines
     // http://eslint.org/docs/rules/no-trailing-spaces
     "no-trailing-spaces": 2,
     // Disallow conditional expressions that can be expressed with simpler constructs
     // http://eslint.org/docs/rules/no-unneeded-ternary
     "no-unneeded-ternary": 2,
+    // Disallow dangling underscores in identifiers
+    // http://eslint.org/docs/rules/no-underscore-dangle
+    "no-underscore-dangle": [2, {
+      "allow": [],
+      "allowAfterThis": false,
+      "allowAfterSuper": false
+    }],
     // Disallow or enforce spaces inside of curly braces in objects
     // http://eslint.org/docs/rules/object-curly-spacing
     "object-curly-spacing": [2, "always"],


### PR DESCRIPTION
- Add `symbol-description` rule
- Add `no-underscore-dangle` rule
- Rename `no-native-reassign` => `no-global-assign`
- Rename `no-negated-in-lhs` => `no-unsafe-negation`
- Rename `no-spaced-func` => `func-call-spacing`
